### PR TITLE
fixed the InTty does not work correctly in linux

### DIFF
--- a/process.go
+++ b/process.go
@@ -194,7 +194,7 @@ func (p *Process) FullCommand() string {
 // InTty returns a true or false depending if p.Tty is ?? or
 // a value such as ttys001.
 func (p *Process) InTty() bool {
-	return p.Tty != "??"
+	return p.Tty[0] != "?"[0]
 }
 
 // OpenTty returns an opened file handle to the tty of the process.


### PR DESCRIPTION
Because in Linux, when no tty, the value is "?" not "??", I didn't test it in other platform, but I think comparing it with the leading "?" is better than hardcode "??".